### PR TITLE
added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+src/*.exe
+src/*.bin
+src/*.app


### PR DESCRIPTION
Added a .gitignore file such that commands like e.g. "git status" ignore the binaries.
This pull request adds the ability that git ignores *.app, *.bin and *.exe files for now.