### PR TITLE
cleanup Makefile: removes comments about hashcat-toolchain

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,8 +5,6 @@
 CFLAGS = -W -Wall -std=c99 -O2 -s
 #CFLAGS = -W -Wall -std=c99 -g
 
-#CC_LINUX32        = /opt/hashcat-toolchain/linux32/bin/i686-hashcat-linux-gnu-gcc
-#CC_LINUX64        = /opt/hashcat-toolchain/linux64/bin/x86_64-hashcat-linux-gnu-gcc
 CC_LINUX32        = gcc
 CC_LINUX64        = gcc
 CC_WINDOWS32      = /usr/bin/i686-w64-mingw32-gcc


### PR DESCRIPTION
hashcat-toolchain was not used by this project for a while. We do not need it anymore.
That's why I suggest that we clean up the Makefile a little bit by removing this confusing comments about hashcat-toolchain.
Thx