### PR TITLE
minor: new license year should be 2018

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2016 Jens Steube
+Copyright (c) 2015-2018 Jens Steube
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2018 Jens Steube
+Copyright (c) 2015-2022 Jens Steube
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
this small fix makes sure that the year within the LICENSE file is up to date (2018)

Happy new year! All the best!

Thanks